### PR TITLE
Fix draw_card with type.

### DIFF
--- a/scripts/deck.js
+++ b/scripts/deck.js
@@ -76,9 +76,9 @@ function Deck()
       case HEART:
         i = Math.floor((Math.random() * 10) + 0); break;
       case DIAMOND:
-        i = Math.floor((Math.random() * 10) + 12); break;
+        i = Math.floor((Math.random() * 10) + 13); break;
       case CLOVE:
-        i = Math.floor((Math.random() * 10) + 24); break;
+        i = Math.floor((Math.random() * 10) + 26); break;
       case SPADE:
         i = Math.floor((Math.random() * 10) + 36); break;
     }


### PR DESCRIPTION
Fix the lower bound on draw_card when the deck is not shuffled. Otherwise it's possible to draw an incorrect type.